### PR TITLE
Ensure the VPN is reconnected after app updates and device reboots

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,8 +37,8 @@
         <service android:name=".service.CheckInService" />
         <service android:name=".service.VpnStateService" />
 
-        <receiver android:name=".receiver.BootReceiver">
-            <intent-filter>
+        <receiver android:name=".receiver.BootReceiver" >
+            <intent-filter android:priority="999">
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>

--- a/app/src/main/java/com/netangel/netangelprotection/receiver/BootReceiver.java
+++ b/app/src/main/java/com/netangel/netangelprotection/receiver/BootReceiver.java
@@ -3,15 +3,11 @@ package com.netangel.netangelprotection.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 
-import com.netangel.netangelprotection.service.CheckInService;
+import com.netangel.netangelprotection.service.VpnStateService;
 import com.netangel.netangelprotection.ui.ConnectVpnActivity;
 import com.netangel.netangelprotection.util.Config;
-import com.netangel.netangelprotection.util.VpnHelper;
-
-import de.blinkt.openvpn.LaunchVPN;
-import de.blinkt.openvpn.VpnProfile;
 
 public class BootReceiver extends BroadcastReceiver {
     @Override
@@ -19,24 +15,19 @@ public class BootReceiver extends BroadcastReceiver {
         String action = intent.getAction();
 
         if ((Intent.ACTION_BOOT_COMPLETED.equals(action) || Intent.ACTION_MY_PACKAGE_REPLACED.equals(action))
-                && Config.getBoolean(context, Config.STATUS_PROTECTED, false)) {
-			VpnProfile profile = new VpnHelper(context).getProfile();
-
-            if (profile != null) {
-                launchVPN(context, profile);
-                CheckInService.start(context);
-            } else {
-                ConnectVpnActivity.start(context, true);
-            }
+                && isSwitchOn(context)) {
+            startVpnConnection(context);
         }
     }
 
-    private static void launchVPN(@NonNull Context context, @NonNull VpnProfile profile) {
-        Intent startVpnIntent = new Intent(Intent.ACTION_MAIN);
-        startVpnIntent.setClass(context, LaunchVPN.class);
-        startVpnIntent.putExtra(LaunchVPN.EXTRA_KEY, profile.getUUIDString());
-        startVpnIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        startVpnIntent.putExtra(LaunchVPN.EXTRA_HIDELOG, true);
-        context.startActivity(startVpnIntent);
+    @VisibleForTesting
+    protected boolean isSwitchOn(Context context) {
+        return Config.getBoolean(context, Config.IS_SWITCH_ON, false);
+    }
+
+    @VisibleForTesting
+    protected void startVpnConnection(Context context) {
+        VpnStateService.start(context);
+        ConnectVpnActivity.start(context, true);
     }
 }

--- a/app/src/main/java/com/netangel/netangelprotection/ui/LoginActivity.java
+++ b/app/src/main/java/com/netangel/netangelprotection/ui/LoginActivity.java
@@ -96,8 +96,8 @@ public class LoginActivity extends AppCompatActivity implements VpnStatus.StateL
 	}
 
 	@Override
-	public void onResume() {
-		super.onResume();
+	public void onStart() {
+		super.onStart();
 		connectToVpn(this, helper);
 	}
 

--- a/app/src/test/java/com/netangel/netangelprotection/receiver/BootReceiverTest.java
+++ b/app/src/test/java/com/netangel/netangelprotection/receiver/BootReceiverTest.java
@@ -1,0 +1,63 @@
+package com.netangel.netangelprotection.receiver;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.netangel.netangelprotection.NetAngelJunitSuite;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+public class BootReceiverTest extends NetAngelJunitSuite {
+
+    private BootReceiver bootReceiver;
+
+    @Mock
+    private Context context;
+    @Mock
+    private Intent intent;
+
+    @Before
+    public void setUp() {
+        bootReceiver = spy(new BootReceiver());
+        doNothing().when(bootReceiver).startVpnConnection(context);
+        doReturn(true).when(bootReceiver).isSwitchOn(context);
+    }
+
+    @Test
+    public void shouldConnectOnBoot() {
+        when(intent.getAction()).thenReturn(Intent.ACTION_BOOT_COMPLETED);
+        bootReceiver.onReceive(context, intent);
+
+        verify(bootReceiver).startVpnConnection(context);
+    }
+
+    @Test
+    public void shouldConnectOnReinstall() {
+        when(intent.getAction()).thenReturn(Intent.ACTION_MY_PACKAGE_REPLACED);
+        bootReceiver.onReceive(context, intent);
+
+        verify(bootReceiver).startVpnConnection(context);
+    }
+
+    @Test
+    public void shouldNotConnectForOtherIntents() {
+        when(intent.getAction()).thenReturn(Intent.ACTION_BATTERY_CHANGED);
+        bootReceiver.onReceive(context, intent);
+
+        verify(bootReceiver, times(0)).startVpnConnection(context);
+    }
+
+    @Test
+    public void shouldNotConnectIfSwitchIsOff() {
+        when(intent.getAction()).thenReturn(Intent.ACTION_BOOT_COMPLETED);
+        doReturn(false).when(bootReceiver).isSwitchOn(context);
+
+        bootReceiver.onReceive(context, intent);
+
+        verify(bootReceiver, times(0)).startVpnConnection(context);
+    }
+}

--- a/app/src/test/java/com/netangel/netangelprotection/ui/LoginActivityTest.java
+++ b/app/src/test/java/com/netangel/netangelprotection/ui/LoginActivityTest.java
@@ -1,0 +1,60 @@
+package com.netangel.netangelprotection.ui;
+
+import android.app.Activity;
+import android.content.Context;
+
+import com.netangel.netangelprotection.NetAngelJunitSuite;
+import com.netangel.netangelprotection.util.VpnHelper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+public class LoginActivityTest extends NetAngelJunitSuite {
+
+    private LoginActivity loginActivity;
+
+    @Mock
+    private VpnHelper vpnHelper;
+    @Mock
+    private Context context;
+
+    @Before
+    public void setUp() {
+        loginActivity = spy(new LoginActivity());
+        doNothing().when(loginActivity).startVpnConnectionActivity(context);
+    }
+
+    @Test
+    public void shouldConnectToVpnWhenHelperSaysItIsNotConnected() {
+        doReturn(true).when(loginActivity).isSwitchOn(context);
+        doReturn(false).when(vpnHelper).isVpnConnected();
+
+        loginActivity.connectToVpn(context, vpnHelper);
+
+        verify(loginActivity).startVpnConnectionActivity(context);
+    }
+
+    @Test
+    public void shouldNotConnectToVpnIfHelperSaysItIsOn() {
+        doReturn(true).when(loginActivity).isSwitchOn(context);
+        doReturn(true).when(vpnHelper).isVpnConnected();
+
+        loginActivity.connectToVpn(context, vpnHelper);
+
+        verify(loginActivity, times(0)).startVpnConnectionActivity(context);
+    }
+
+    @Test
+    public void shouldNotConnectToVpnIfSwitchIsOff() {
+        doReturn(false).when(loginActivity).isSwitchOn(context);
+        doReturn(false).when(vpnHelper).isVpnConnected();
+
+        loginActivity.connectToVpn(context, vpnHelper);
+
+        verify(loginActivity, times(0)).startVpnConnectionActivity(context);
+    }
+}

--- a/app/src/test/java/com/netangel/netangelprotection/util/VpnHelperTest.java
+++ b/app/src/test/java/com/netangel/netangelprotection/util/VpnHelperTest.java
@@ -1,0 +1,67 @@
+package com.netangel.netangelprotection.util;
+
+import android.content.Context;
+
+import com.netangel.netangelprotection.NetAngelJunitSuite;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+public class VpnHelperTest extends NetAngelJunitSuite {
+
+    private VpnHelper helper;
+
+    @Mock
+    private Context context;
+
+    @Before
+    public void setUp() {
+        helper = spy(new VpnHelper(context));
+    }
+
+    @Test
+    public void shouldMarkConnectedForTunConnection() throws SocketException {
+        doReturn(generateInterfaces("tun0", "wlan0", "dummy0")).when(helper).getNetworkInterfaces();
+        assertTrue(helper.isVpnConnected());
+    }
+
+    @Test
+    public void shouldMarkConnectedForPptpConnection() throws SocketException {
+        doReturn(generateInterfaces("pptp0", "wlan0", "dummy0")).when(helper).getNetworkInterfaces();
+        assertTrue(helper.isVpnConnected());
+    }
+
+    @Test
+    public void shouldNotMarkConnectedforWlanConnection() throws SocketException {
+        doReturn(generateInterfaces("wlan0", "dummy0")).when(helper).getNetworkInterfaces();
+        assertFalse(helper.isVpnConnected());
+    }
+
+    @Test
+    public void shouldNotMarkConnectedOnSocketException() throws SocketException {
+        doThrow(new SocketException("fail trying to find connections")).when(helper).getNetworkInterfaces();
+        assertFalse(helper.isVpnConnected());
+    }
+
+    private List<VpnHelper.NetworkInterfaceWrapper> generateInterfaces(String ... names) throws SocketException {
+        List<VpnHelper.NetworkInterfaceWrapper> interfaces = new ArrayList<>();
+
+        for (String s : names) {
+            VpnHelper.NetworkInterfaceWrapper networkInterface =
+                    new VpnHelper.NetworkInterfaceWrapper(s, true);
+
+            interfaces.add(networkInterface);
+        }
+
+        return interfaces;
+    }
+}


### PR DESCRIPTION
This PR addresses #9.

The way that Android manages this is through a [BroadcastReceiver](https://developer.android.com/reference/android/content/BroadcastReceiver.html). Whenever the device is rebooted, or the app is replaced (updated), we tell the system that we want to know about it, by adding it to our [AndroidManifest](https://github.com/klinker24/netangel-protection-android/blob/boot_fix/app/src/main/AndroidManifest.xml#L40).

When those actions do go off, eventually Android will tell us about them. I say eventually, because, especially in the case of the device reboot, it isn't immediate. It usually takes about 30 seconds before apps start receiving this broadcast and can handle it, because all the system services need to start up first.

All of the VPN connection logic will happen in the background, within ~15-30 seconds of the user turning on the device and unlocking it, the VPN will connect and start monitoring. It should be completely seamless for the user.


Along with these boot changes, I also tweaked the way the VPN is started when the app is launched. If, for whatever reason (network goes out, app crashes, etc), the VPN goes down, it will immediately try to reconnect when the app is launched again. Before, the user would have to log in, then toggle the VPN switch off, then back on. This was a complaint from one of the users, so now, it will all be automatic.