### PR TITLE
Force reconnect even when the user exits with the home button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,11 +31,13 @@
 
         <activity
             android:name=".ui.ConnectVpnActivity"
+            android:launchMode="singleInstance"
             android:excludeFromRecents="true"
             android:theme="@style/Theme.NetAngel.Translucent" />
 
         <service android:name=".service.CheckInService" />
         <service android:name=".service.VpnStateService" />
+        <service android:name=".service.VpnReconnectService" />
 
         <receiver android:name=".receiver.BootReceiver">
             <intent-filter>

--- a/app/src/main/java/com/netangel/netangelprotection/service/VpnReconnectService.java
+++ b/app/src/main/java/com/netangel/netangelprotection/service/VpnReconnectService.java
@@ -1,0 +1,40 @@
+package com.netangel.netangelprotection.service;
+
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+
+import com.netangel.netangelprotection.ui.ConnectVpnActivity;
+
+public class VpnReconnectService extends IntentService {
+
+    private static final String WAIT_TIME_BEFORE_REQUEST = "wait_time";
+
+    public VpnReconnectService() {
+        super("VpnReconnectService");
+    }
+
+    public static void start(Context context) {
+        start(context, 0);
+    }
+
+    public static void start(Context context, long waitTime) {
+        Intent connectService = new Intent(context, VpnReconnectService.class);
+        connectService.putExtra(WAIT_TIME_BEFORE_REQUEST, waitTime);
+
+        context.startService(connectService);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        long waitTime = intent.getLongExtra(WAIT_TIME_BEFORE_REQUEST, 0L);
+
+        try {
+            Thread.sleep(waitTime);
+        } catch (InterruptedException e) {
+
+        }
+
+        ConnectVpnActivity.start(this, true);
+    }
+}

--- a/app/src/main/java/com/netangel/netangelprotection/service/VpnStateService.java
+++ b/app/src/main/java/com/netangel/netangelprotection/service/VpnStateService.java
@@ -83,7 +83,7 @@ public class VpnStateService extends Service implements VpnStatus.StateListener 
         if (level == VpnStatus.ConnectionStatus.LEVEL_WAITING_FOR_USER_INPUT ||
                 level == VpnStatus.ConnectionStatus.LEVEL_CONNECTING_NO_SERVER_REPLY_YET ||
                 level == VpnStatus.ConnectionStatus.LEVEL_CONNECTING_SERVER_REPLIED) {
-            startForeground(R.string.connecting_to_vpn, false);
+            startForeground(R.string.connecting_to_vpn, true);
         } else if (level == VpnStatus.ConnectionStatus.LEVEL_CONNECTED) {
             protectionManager.setProtected(this, true);
             startForeground(R.string.device_protected, true);

--- a/app/src/main/java/com/netangel/netangelprotection/service/VpnStateService.java
+++ b/app/src/main/java/com/netangel/netangelprotection/service/VpnStateService.java
@@ -54,7 +54,7 @@ public class VpnStateService extends Service implements VpnStatus.StateListener 
         // by starting a background service as a foreground service, we are ensuring that
         // Android does not go in and wipe it out without us knowing.
         // https://developer.android.com/guide/components/services.html#Foreground
-        startForeground(R.string.connecting_to_vpn);
+        startForeground(R.string.connecting_to_vpn, true);
 
         // We want this service to attempt to continue running until it is explicitly stopped
         return START_STICKY;
@@ -80,19 +80,17 @@ public class VpnStateService extends Service implements VpnStatus.StateListener 
     public void updateState(String state, String logmessage, int localizedResId,
                             VpnStatus.ConnectionStatus level, VpnStatus.ConnectionStatus prevLevel) {
 
-        // TODO: Rework the logic here?
-        // Haven't tested enough yet, but do we really care about the previous level?
-        // Seems like we should really just care about the current state. This isn't really a
-        // state machine, that is handled for us in the StateListener, this is just reacting to changes.
-
-        if (prevLevel == VpnStatus.ConnectionStatus.LEVEL_CONNECTING_SERVER_REPLIED
-                && level == VpnStatus.ConnectionStatus.LEVEL_CONNECTED) {
+        if (level == VpnStatus.ConnectionStatus.LEVEL_WAITING_FOR_USER_INPUT ||
+                level == VpnStatus.ConnectionStatus.LEVEL_CONNECTING_NO_SERVER_REPLY_YET ||
+                level == VpnStatus.ConnectionStatus.LEVEL_CONNECTING_SERVER_REPLIED) {
+            startForeground(R.string.connecting_to_vpn, false);
+        } else if (level == VpnStatus.ConnectionStatus.LEVEL_CONNECTED) {
             protectionManager.setProtected(this, true);
-            startForeground(R.string.device_protected);
+            startForeground(R.string.device_protected, true);
         } else if (prevLevel == VpnStatus.ConnectionStatus.LEVEL_CONNECTED
                 && level == VpnStatus.ConnectionStatus.LEVEL_NOTCONNECTED) {
             protectionManager.setProtected(this, false);
-            startForeground(R.string.device_not_protected);
+            startForeground(R.string.device_not_protected, true);
 
             if (protectionManager.isDisconnectedByApp()) {
                 protectionManager.setDisconnectedByApp(false);
@@ -100,18 +98,18 @@ public class VpnStateService extends Service implements VpnStatus.StateListener 
                 restartVpnConnection();
             }
         } else if (level == VpnStatus.ConnectionStatus.LEVEL_NONETWORK) {
-            startForeground(R.string.failed_to_connect);
+            startForeground(R.string.failed_to_connect, true);
             protectionManager.setProtected(this, false);
         }
     }
 
     @VisibleForTesting
-    protected void startForeground(@StringRes int text) {
+    protected void startForeground(@StringRes int text, boolean hideNotification) {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle(getString(R.string.connection_status))
                 .setContentText(getString(text))
-                .setPriority(NotificationCompat.PRIORITY_MIN)
+                .setPriority(hideNotification ? NotificationCompat.PRIORITY_MIN : NotificationCompat.PRIORITY_HIGH)
                 .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
                 .setWhen(0);
 

--- a/app/src/test/java/com/netangel/netangelprotection/service/VpnStateServiceTest.java
+++ b/app/src/test/java/com/netangel/netangelprotection/service/VpnStateServiceTest.java
@@ -135,7 +135,7 @@ public class VpnStateServiceTest extends NetAngelRobolectricSuite {
         VpnStatus.ConnectionStatus current = VpnStatus.ConnectionStatus.LEVEL_CONNECTING_SERVER_REPLIED;
 
         updateState(current, previous);
-        verify(service).startForeground(R.string.connecting_to_vpn, false);
+        verify(service).startForeground(R.string.connecting_to_vpn, true);
         verifyNoMoreInteractions(manager);
     }
 

--- a/app/src/test/java/com/netangel/netangelprotection/service/VpnStateServiceTest.java
+++ b/app/src/test/java/com/netangel/netangelprotection/service/VpnStateServiceTest.java
@@ -91,7 +91,7 @@ public class VpnStateServiceTest extends NetAngelRobolectricSuite {
         VpnStatus.ConnectionStatus current = VpnStatus.ConnectionStatus.LEVEL_CONNECTED;
 
         updateState(current, previous);
-        verify(service).startForeground(R.string.device_protected);
+        verify(service).startForeground(R.string.device_protected, true);
         verify(manager).setProtected(service, true);
     }
 
@@ -102,7 +102,7 @@ public class VpnStateServiceTest extends NetAngelRobolectricSuite {
         VpnStatus.ConnectionStatus current = VpnStatus.ConnectionStatus.LEVEL_NOTCONNECTED;
 
         updateState(current, previous);
-        verify(service).startForeground(R.string.device_not_protected);
+        verify(service).startForeground(R.string.device_not_protected, true);
         verify(service).restartVpnConnection();
         verify(manager).setProtected(service, false);
     }
@@ -114,7 +114,7 @@ public class VpnStateServiceTest extends NetAngelRobolectricSuite {
         VpnStatus.ConnectionStatus current = VpnStatus.ConnectionStatus.LEVEL_NOTCONNECTED;
 
         updateState(current, previous);
-        verify(service).startForeground(R.string.device_not_protected);
+        verify(service).startForeground(R.string.device_not_protected, true);
         verify(manager).setProtected(service, false);
         verify(manager).setDisconnectedByApp(false);
     }
@@ -125,8 +125,18 @@ public class VpnStateServiceTest extends NetAngelRobolectricSuite {
         VpnStatus.ConnectionStatus current = VpnStatus.ConnectionStatus.LEVEL_NONETWORK;
 
         updateState(current, previous);
-        verify(service).startForeground(R.string.failed_to_connect);
+        verify(service).startForeground(R.string.failed_to_connect, true);
         verify(manager).setProtected(service, false);
+    }
+
+    @Test
+    public void shouldMarkAsConnecting() {
+        VpnStatus.ConnectionStatus previous = VpnStatus.ConnectionStatus.LEVEL_CONNECTING_NO_SERVER_REPLY_YET;
+        VpnStatus.ConnectionStatus current = VpnStatus.ConnectionStatus.LEVEL_CONNECTING_SERVER_REPLIED;
+
+        updateState(current, previous);
+        verify(service).startForeground(R.string.connecting_to_vpn, false);
+        verifyNoMoreInteractions(manager);
     }
 
     private void updateState(VpnStatus.ConnectionStatus level, VpnStatus.ConnectionStatus previousLevel) {

--- a/app/src/test/java/com/netangel/netangelprotection/ui/ConnectVpnActivityTest.java
+++ b/app/src/test/java/com/netangel/netangelprotection/ui/ConnectVpnActivityTest.java
@@ -1,0 +1,57 @@
+package com.netangel.netangelprotection.ui;
+
+import android.content.Context;
+
+import com.netangel.netangelprotection.NetAngelJunitSuite;
+import com.netangel.netangelprotection.NetAngelRobolectricSuite;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+public class ConnectVpnActivityTest extends NetAngelJunitSuite {
+
+    private ConnectVpnActivity activity;
+
+    @Mock
+    private Context context;
+
+    @Before
+    public void setUp() {
+        activity = spy(new ConnectVpnActivity());
+        doNothing().when(activity).restartActivity(context);
+    }
+
+    @Test
+    public void shouldReconnect() {
+        activity.setVpnConfirmed(false);
+        activity.setForceConfirm(true);
+
+        activity.getHomePressedReceiver().onReceive(context, null);
+
+        verify(activity).restartActivity(context);
+    }
+
+    @Test
+    public void hasAlreadyReconnected() {
+        activity.setVpnConfirmed(true);
+        activity.setForceConfirm(true);
+
+        activity.getHomePressedReceiver().onReceive(context, null);
+
+        verify(activity, times(0)).restartActivity(context);
+    }
+
+    @Test
+    public void doesNotNeedToForceReconnect() {
+        activity.setVpnConfirmed(false);
+        activity.setForceConfirm(false);
+
+        activity.getHomePressedReceiver().onReceive(context, null);
+
+        verify(activity, times(0)).restartActivity(context);
+    }
+}


### PR DESCRIPTION
This PR addresses #6.

After some digging for the best way to accomplish this, I found that the system can send out a broadcast for `Intent.ACTION_CLOSE_SYSTEM_DIALOGS`. This is really useful for us, since that is exactly what happens when the user clicks the home button. 

This is a system dialog, alerting the user that VPN's cannot always be trusted, and it is required to be shown when making a connection request:
![screenshot_20170129-102426](https://cloud.githubusercontent.com/assets/4874287/22405757/441d5112-e60d-11e6-98b2-474cb12e0729.png)


Unfortunately, since it was a system dialog and not a component that we really control, it made it difficult to listen to changes or cancellations, other than the callbacks that it provided ("OK" and "Cancel" buttons are provided callbacks).

So, after listening for this broadcast, we are finally able to tell when the home button is clicked. When it is clicked:
1. We start an `IntentService` that will wait 1.5 seconds before attempting another connection request.
2. When it is requested, it will come up again, over any apps that are opened. So it will basically pester them until they accept the request again.

So now, the only way to turn off the app's VPN is by doing so through the toggle on the UI.

Some things to note about this:
- The `IntentService` will wait 1.5 seconds before requesting the connection again, but the system takes a few extra to process that request. On my device, the dialog would come up about every 5 seconds. I don't think that there will be a way around this, but I don't think it is a major issue either, 5 seconds isn't enough time to do anything.
- If the device is restarted during this connection dialog, this PR will work great with #14. That PR will ensure that, if the switch has been marked as "on" within the UI, it will always connect ASAP after the device reboot.
- A notification will not be shown whenever the device is trying to connect to the VPN. This can be seen in the screenshot above. Just so the user has a bit of an indication that something is happening.


Let's hold off just a few days on merging this one, just so I can play around a bit, in everyday usage. Seems to be very solid, based on today though. Have not been able to get around the VPN at all, yet.

-----

I am trying to think of more methods around the VPN connection, but not coming up with much. Does anyone else have ideas or thoughts about how the user can get around it?