### PR TITLE
Send the correct device type to the backend

### DIFF
--- a/app/src/main/java/com/netangel/netangelprotection/restful/RestfulApi.java
+++ b/app/src/main/java/com/netangel/netangelprotection/restful/RestfulApi.java
@@ -32,6 +32,7 @@ public class RestfulApi {
 	private static final String CLIENT_ID = "client_id";
 	private static final String NAME = "name";
 	private static final String DEVICE_TYPE = "device_type";
+	private static final String DEVICE_NAME = "device_name";
 	private static final String MODEL_NAME = "model_name";
 	private static final String MODEL_NUMBER = "model_number";
 	private static final String OS = "os";
@@ -84,7 +85,7 @@ public class RestfulApi {
 		HashMap<String, String> args = new HashMap<>();
 		args.put(CLIENT_ID, clientId);
 		args.put(NAME, Device.getName());
-		args.put(DEVICE_TYPE, "phone");
+		args.put(DEVICE_TYPE, Device.getDeviceType(context));
 		args.put(MODEL_NAME, Device.getName());
 		args.put(MODEL_NUMBER, Device.getModel());
 		args.put(OS, Device.getOS());

--- a/app/src/main/java/com/netangel/netangelprotection/util/Device.java
+++ b/app/src/main/java/com/netangel/netangelprotection/util/Device.java
@@ -1,12 +1,12 @@
 package com.netangel.netangelprotection.util;
 
+import android.content.Context;
 import android.os.Build;
+
+import com.netangel.netangelprotection.R;
 
 import org.apache.commons.lang3.StringUtils;
 
-/**
- * Created by DuyTran on 6/21/2016.
- */
 public final class Device {
 
 	private Device() {}
@@ -19,6 +19,10 @@ public final class Device {
 		} else {
 			return StringUtils.capitalize(manufacturer + " " + model);
 		}
+	}
+
+	public static String getDeviceType(Context context) {
+		return context.getString(R.string.device_type);
 	}
 
 	public static String getModel() {

--- a/app/src/main/res/values-sw600dp/strings.xml
+++ b/app/src/main/res/values-sw600dp/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="device_type">tablet</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="loading">Loading</string>
     <string name="vpn_disabled">VPN connection is disabled</string>
     <string name="check_internet_connection">Check Internet connection</string>
+    <string name="device_type">phone</string>
 
     <!-- LoginActivity -->
     <string name="email">Email</string>
@@ -28,5 +29,7 @@
     <!-- VpnStateService -->
     <string name="connection_status">Connection Status</string>
     <string name="connecting_to_vpn">Connecting to NetAngel…</string>
+
+
 
 </resources>

--- a/app/src/test/java/com/netangel/netangelprotection/util/DeviceTest.java
+++ b/app/src/test/java/com/netangel/netangelprotection/util/DeviceTest.java
@@ -1,0 +1,34 @@
+package com.netangel.netangelprotection.util;
+
+import android.content.Context;
+
+import com.netangel.netangelprotection.NetAngelRobolectricSuite;
+import com.netangel.netangelprotection.R;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.*;
+
+import static org.junit.Assert.*;
+
+public class DeviceTest extends NetAngelRobolectricSuite {
+
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.application;
+    }
+
+    @Test
+    public void shouldFindScreenSizeResourceForPhone() {
+        assertEquals("phone", context.getString(R.string.device_type));
+    }
+
+    @Test
+    @org.robolectric.annotation.Config(qualifiers="sw600dp")
+    public void shouldFindScreenSizeResourcesForTablet() {
+        assertEquals("tablet", context.getString(R.string.device_type));
+    }
+}


### PR DESCRIPTION
Fixes #2.

In Android, since there are so many different devices, configurations, manufacturers, skins, etc, we manage the device types by the screen sizes, since it is impossible to code for all of them individually.

Android provides `res` folders that can be overrode depending on device configuration. Some things that can go into resource identifiers are:

- Screen Size
- Orientation
- Language/Regionalization
- Left-to-Right vs Right-to-Left countries
- Android SDK version (Lollipop, Marshmallow, Nougat, etc)

This allows developers to do one thing in code, like referencing a layout, and have it change if you are on tablet vs phone. For example, if you are on a phone and were looking for the layout of the main activity with `R.layout.activity_main`, it would look in the `/main/res/layout` directory. However, if you are on a tablet, it would look first in the `/main/res/layout-sw600dp` folder. If the layout existed in that folder, it would be applied from there. If it didn't exist in that folder, Android would grab the layout from the original `/main/res/layout` directory instead.

---

This changes add a string resource to the `/main/res/values/strings.xml` file for `phone`, then adds one for `tablet` in the `/main/res/values-sw600dp/strings.xml` that overwrites the original, when the user is using a tablet.`sw600dp` references the screen width of 600 dp or larger (sw = "screen width")