### PR TITLE
Stop the app from changing the devices wifi on/off state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
 
     <application
         android:name=".NetAngelApplication"

--- a/app/src/main/java/com/netangel/netangelprotection/service/CheckInService.java
+++ b/app/src/main/java/com/netangel/netangelprotection/service/CheckInService.java
@@ -5,15 +5,8 @@ import android.app.IntentService;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.hardware.display.DisplayManager;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.net.wifi.WifiManager;
-import android.os.Build;
-import android.os.PowerManager;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.content.LocalBroadcastManager;
-import android.view.Display;
 
 import com.netangel.netangelprotection.model.CheckInResult;
 import com.netangel.netangelprotection.restful.RestfulApi;

--- a/ics-openvpn/src/main/java/de/blinkt/openvpn/core/DeviceStateReceiver.java
+++ b/ics-openvpn/src/main/java/de/blinkt/openvpn/core/DeviceStateReceiver.java
@@ -12,7 +12,6 @@ import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.NetworkInfo.State;
-import android.net.wifi.WifiManager;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 
@@ -152,16 +151,8 @@ public class DeviceStateReceiver extends BroadcastReceiver implements ByteCountL
                     screen = connectState.DISCONNECTED;
 
                 mManagement.pause(getPauseReason());
-
-                WifiManager wifi = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
-                wifi.setWifiEnabled(false);
-
             }
         } else if (Intent.ACTION_SCREEN_ON.equals(intent.getAction())) {
-
-            WifiManager wifi = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
-            wifi.setWifiEnabled(true);
-
             // Network was disabled because screen off
             boolean connected = shouldBeConnected();
             screen = connectState.SHOULDBECONNECTED;
@@ -204,16 +195,6 @@ public class DeviceStateReceiver extends BroadcastReceiver implements ByteCountL
             String extrainfo = networkInfo.getExtraInfo();
             if (extrainfo == null)
                 extrainfo = "";
-
-			/*
-            if(networkInfo.getType()==android.net.ConnectivityManager.TYPE_WIFI) {
-				WifiManager wifiMgr = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
-				WifiInfo wifiinfo = wifiMgr.getConnectionInfo();
-				extrainfo+=wifiinfo.getBSSID();
-
-				subtype += wifiinfo.getNetworkId();
-			}*/
-
 
             netstatestring = String.format("%2$s %4$s to %1$s %3$s", networkInfo.getTypeName(),
                     networkInfo.getDetailedState(), extrainfo, subtype);


### PR DESCRIPTION
Brian got in touch with me today, saying that, on one customer's Galaxy S5, whenever he downloads the app, he is forced onto wifi, then, whenever he turns his screen off, the app automatically reconnected him to wifi, again.

I did some digging and found that this was in fact happening in the [ics-openvpn#DeviceStateReceiver](https://github.com/net-angel/netangel-protection-android/blob/f53a50eee4a02b0875992ecc05dec45b8f26702c/ics-openvpn/src/main/java/de/blinkt/openvpn/core/DeviceStateReceiver.java#L156). There is really no reason for this to happen. I imagine that it was part of the battery saving effort (#13) at some point, but it just makes for a terrible experience for the user. This code is not present in the [upstream dependency](https://github.com/schwabe/ics-openvpn/blob/c6d7fcd124b62ac62960ae0c5a701bf7a886379d/main/src/main/java/de/blinkt/openvpn/core/DeviceStateReceiver.java#L153), so it was definitely added manually to the app, and is unnecessary.

It looks like, the reason that I hadn't seen it, nor had we heard about it before, was because of some permission issues. Some permissions have to be granted by the user in Android 6.0+, but were given to any app that requested them, on older versions of Android.

I have removed this functionality, as well as the permission declaration, and confirmed that the VPN is still able to connect like normal.