### PR TITLE
Notification/message improvements

### DIFF
--- a/app/src/main/java/com/netangel/netangelprotection/NetAngelApplication.java
+++ b/app/src/main/java/com/netangel/netangelprotection/NetAngelApplication.java
@@ -24,7 +24,10 @@ public class NetAngelApplication extends Application {
 
         PRNGFixes.apply();
         VpnStatus.initLogCache(getCacheDir());
-        VpnStateService.start(this);
-        CheckInService.start(this);
+
+        if (Config.getBoolean(this, Config.IS_SWITCH_ON, false)) {
+            VpnStateService.start(this);
+            CheckInService.start(this);
+        }
     }
 }

--- a/app/src/main/java/com/netangel/netangelprotection/ui/LoginActivity.java
+++ b/app/src/main/java/com/netangel/netangelprotection/ui/LoginActivity.java
@@ -161,7 +161,7 @@ public class LoginActivity extends AppCompatActivity implements VpnStatus.StateL
 				String email = edtEmail.getText().toString().trim();
 				String password = edtPassword.getText().toString().trim();
 				new LoginTask(this, email, password).execute();
-				progressDialog = ProgressDialog.show(this, "", getString(R.string.connecting_to_vpn), true);
+				progressDialog = ProgressDialog.show(this, "", getString(R.string.signing_in), true);
 			} else {
 				Snackbar.make(edtEmail, R.string.check_internet_connection, Snackbar.LENGTH_LONG).show();
 			}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="invalid_email_message">Invalid email</string>
     <string name="password_length_message">Your password has to be at least 8 characters</string>
     <string name="login_failed_message">Login failed</string>
+    <string name="signing_in">Signing in to NetAngel…</string>
 
     <!-- MainActivity -->
     <string name="device_protected">Device is protected</string>


### PR DESCRIPTION
Fixes #23 and #22.

This will just make it so that the notification and listener service is not started unless the the has logged in and the switch is turned on.

So, if the user open the app for the first time, neither of these services will get started, so there won't be a notification.

It also changes the message when the user is signing in. It now will read "Signing in to NetAngel..." instead of the old "Connecting to NetAngel..."